### PR TITLE
Dockerize the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ python3 app.py --haarcascade --video
 
 ```bash
 docker run --rm \
-  --device=/dev/video0:/dev/video0 \
+  --privileged \
+  --net=host \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
   eye-tracking-app \
-  --mediapipe --video
+  python app.py --mediapipe --video
 ```
 
 ```bash
 python3 app.py --mediapipe --video
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ To process an image with Haarcascade or Mediapipe, use the following commands:
 **Haarcascade:**
 
 ```bash
-docker run --rm \
-  eye-tracking-app \
-  --haarcascade
-```
-
-```bash
 python3 app.py --haarcascade
 ```
 
@@ -43,8 +37,9 @@ python3 app.py --haarcascade
 
 ```bash
 docker run --rm \
-  eye-tracking-app \
-  --mediapipe
+ --net=host \
+ --privileged \
+ eye-tracking-app
 ```
 
 ```bash
@@ -57,27 +52,10 @@ If you want to use real-time video tracking (e.g., via webcam), add the --video 
 **Haarcascade with Videos:**
 
 ```bash
-docker run --rm \
-  --device=/dev/video0:/dev/video0 \
-  eye-tracking-app \
-  --haarcascade --video
-```
-
-```bash
 python3 app.py --haarcascade --video
 ```
 
 **Mediapipe with Video:**
-
-```bash
-docker run --rm \
-  --privileged \
-  --net=host \
-  -e DISPLAY=$DISPLAY \
-  -v /tmp/.X11-unix:/tmp/.X11-unix \
-  eye-tracking-app \
-  python app.py --mediapipe --video
-```
 
 ```bash
 python3 app.py --mediapipe --video

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,9 +1,15 @@
-FROM python:latest
+FROM python:3.12.3-slim
 
 WORKDIR /app
 
 COPY . /app
 
 RUN pip install -r requirements.txt
+
+RUN apt-get update && apt-get install -y \
+    libgl1 \
+    libglib2.0-0
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 CMD ["python", "app.py"]

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update && apt-get install -y \
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-CMD ["python", "app.py"]
+CMD ["python", "app.py", "--mediapipe"]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-mediapipe==0.10.18
+mediapipe==0.10.15
 opencv_contrib_python==4.10.0.84
 opencv_python==4.10.0.84
 opencv_python_headless==4.10.0.84


### PR DESCRIPTION
Could you please check if you are able to start the python script out of the docker container. I have read its not possible on Mac.

Getting started:
https://www.docker.com/get-started/

It would be nice if we could get this working at least on Windows

You can use this commands:

docker run --rm \
  --privileged \
  --net=host \
  -e DISPLAY=$DISPLAY \
  -v /tmp/.X11-unix:/tmp/.X11-unix \
  eye-tracking-app \
  python app.py --mediapipe --video
  
 Dockerfile (last two run commands)
 The first command installs system-level libraries necessary for the application to run (in this case, OpenGL and GLib).
The second command cleans up temporary files created during the package installation process to keep the final Docker image small and efficient.
  
 The command provided runs a Docker container with various configurations and parameters for running an eye-tracking application.

1. docker run --rm
docker run: Starts a new container from a specified image (eye-tracking-app in this case).
--rm: Automatically removes the container when it stops, so no container leftovers remain after execution.
2. --privileged
This grants the container elevated privileges, allowing it to access hardware resources on the host system that are typically restricted. This is likely needed for the eye-tracking application to interact with the webcam or other hardware.
3. --net=host
This tells Docker to use the host's network stack instead of creating an isolated one for the container.
It allows the container to access the host system's networking interfaces directly. This is often used for applications that need low-latency network communication or direct access to the host's network devices.
4. -e DISPLAY=$DISPLAY
Sets an environment variable (DISPLAY) in the container to the value of the host's DISPLAY variable.
The DISPLAY variable is used in X11 systems (Linux GUI systems) to specify which display server to connect to. This allows the container to render GUI output (if any) on the host system's display.
5. -v /tmp/.X11-unix:/tmp/.X11-unix
Mounts the host's X11 Unix socket directory (/tmp/.X11-unix) into the container.
This is required for GUI applications to communicate with the X server on the host for rendering graphics or windows. It works alongside the DISPLAY variable.
6. eye-tracking-app
This specifies the Docker image to use for creating the container. The image likely contains the necessary dependencies and application code for the eye-tracking app.
7. python app.py --mediapipe --video
Runs the app.py Python script inside the container.
--mediapipe: Indicates that the app should use the MediaPipe library for processing, which is commonly used for computer vision tasks like face or hand tracking.
--video: Likely specifies that the app should process video input (e.g., from a webcam or video file).
